### PR TITLE
fix: pass observed=False to groupby for pandas 3.0 compatibility

### DIFF
--- a/sarawater/reach.py
+++ b/sarawater/reach.py
@@ -279,7 +279,7 @@ class Reach:
                 right=False,
                 labels=phi_classes[:-1],
             )
-            phi_percentages = dfphi.groupby("Phi Interval")["Percent"].sum()
+            phi_percentages = dfphi.groupby("Phi Interval", observed=False)["Percent"].sum()
             if 7.5 not in phi_percentages.index:
                 phi_percentages.loc[7.5] = 0.0
         else:


### PR DESCRIPTION
## Problem

In pandas 2.0+, the default for `groupby` on `Categorical` columns changed from `observed=False` to `observed=True`. This broke `Reach.add_cross_section_info()` when a scalar D50 value is passed as `grain_data`.

### Root cause

```python
phi_percentages = dfphi.groupby("Phi Interval")["Percent"].sum()
```

With `observed=True` (new default), only bins that actually contain data are returned. For a scalar D50 input only one phi bin has data, so `phi_percentages` ends up with 1–2 entries instead of the expected 18.

When `compute_sediment_load` later calls:

```python
Fi = self.reach.phi_percentages.values          # 2 elements
D50 = 2 ** (-np.interp(0.5, np.cumsum(Fi), sed_range)) / 1000  # sed_range = 18 elements
```

NumPy raises:
```
ValueError: fp and xp are not of the same length
```

## Fix

Explicitly pass `observed=False` to restore the pre-pandas-2.0 behaviour and ensure all phi class bins are always present in the result:

```python
phi_percentages = dfphi.groupby("Phi Interval", observed=False)["Percent"].sum()
```

## Testing

All 62 tests pass after the fix (previously 61/62, with `test_export_scenarios_summary_with_annual_sediment_budget` failing).

```
62 passed, 2 warnings in 15.24s
```

Co-Authored-By: Oz <oz-agent@warp.dev>